### PR TITLE
Remove USE_L10N in django_version > 3 projects

### DIFF
--- a/src/django/python/settings.py
+++ b/src/django/python/settings.py
@@ -107,8 +107,6 @@ TIME_ZONE = 'UTC'
 
 USE_I18N = True
 
-USE_L10N = True
-
 USE_TZ = True
 
 

--- a/src/django/rendering.js
+++ b/src/django/rendering.js
@@ -470,6 +470,10 @@ CHANNEL_LAYERS = {
 }`
     }
 
+    if(project.django_version < 4){
+      _settings += '\nUSE_L10N = True'
+    }
+
     return _settings
   }
 


### PR DESCRIPTION
USE_L10N was switched from a default of False, to True in Django 4.x series, and now issues a RemovedInDjango50Warning when running pytest

> RemovedInDjango50Warning: The USE_L10N setting is deprecated.
> Starting with Django 5.0, localized formatting of data will always be enabled.
> For example Django will display numbers and dates using the format of the current locale.

https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-USE_L10N

So, let's go ahead and remove the setting completely if a Django project is a 4.x project, while still setting it to True in older projects