### PR TITLE
More Abstract Model fixes 

### DIFF
--- a/src/django/rendering.js
+++ b/src/django/rendering.js
@@ -220,7 +220,7 @@ class Renderer {
 
       if (app == undefined) return
 
-      const models = this.get_models(app_id)
+      const models = this.get_models(app_id).filter(model => !model.abstract)
 
       let model_templates = []
 

--- a/src/django/rendering.js
+++ b/src/django/rendering.js
@@ -965,7 +965,7 @@ CHANNEL_LAYERS = {
     api += 'from . import serializers\n'
     api += 'from . import models\n'
 
-    const models = this.get_models(appid).filter(model => !model.abstract);
+    const models = this.get_models(appid).filter(model => !model.abstract)
 
 
     models.forEach((model) => {
@@ -1015,7 +1015,7 @@ CHANNEL_LAYERS = {
     admin += 'from . import models\n'
     admin += '\n\n'
 
-    const models = this.get_models(appid).filter(model => !model.abstract);
+    const models = this.get_models(appid).filter(model => !model.abstract)
 
     models.forEach((model) => {
       admin += 'class ' + model.name + 'AdminForm(forms.ModelForm):\n'

--- a/src/django/rendering.js
+++ b/src/django/rendering.js
@@ -615,7 +615,7 @@ CHANNEL_LAYERS = {
 
     apps.forEach((app) => {
       output += `\n<div class="m-2"><h4>${app.name}</h4></div>`
-      this.get_models(app.id).forEach((model) => {
+      this.get_models(app.id).filter(model => !model.abstract).forEach((model) => {
         output += `\n<div class="m-2"><a class="btn btn-light" href="{% url '${app.name}_${model.name}_list' %}">${model.name} Listing</a></div>`
       })
     })
@@ -639,7 +639,7 @@ CHANNEL_LAYERS = {
     const apps = this.get_apps(projectid);
     let htmx_body = ""
     apps.forEach((app) => {
-      const models = this.get_models(app.id)
+      const models = this.get_models(app.id).filter(model => !model.abstract)
       models.forEach((model) => {
         htmx_body += `
       <div class="col col-lg-6">
@@ -985,7 +985,7 @@ CHANNEL_LAYERS = {
     serializers += '\n'
     serializers += 'from . import models\n'
 
-    const models = this.get_models(appid)
+    const models = this.get_models(appid).filter(model => !model.abstract)
     
     models.forEach((model) => {
       const fields = this.get_fields(model)

--- a/src/django/rendering.js
+++ b/src/django/rendering.js
@@ -965,7 +965,8 @@ CHANNEL_LAYERS = {
     api += 'from . import serializers\n'
     api += 'from . import models\n'
 
-    const models = this.get_models(appid)
+    const models = this.get_models(appid).filter(model => !model.abstract);
+
 
     models.forEach((model) => {
       api += '\n\n'

--- a/src/django/rendering.js
+++ b/src/django/rendering.js
@@ -907,7 +907,7 @@ CHANNEL_LAYERS = {
     urls += '\n\n'
     urls += 'router = routers.DefaultRouter()\n'
 
-    const models = this.get_models(appid)
+    const models = this.get_models(appid).filter(model => !model.abstract)
 
     models.forEach((model) => {
       urls += 'router.register("' + model.name + '", api.' + model.name + 'ViewSet)\n'


### PR DESCRIPTION
(Hope the multiple edits here isn't too messy - if need be, we can roll it up into one.)

Regarding Issue #194 - the fixes pushed a few days ago in 0e1ef96 didn't handle all of the issues, so I've replicated the ``filter(model => !model.abstract)` in a few other generators:

- `api_py()`
- `urls_py()`
- `index_htm()`
- `htmx_htm()`
- `serializers()`

All of those seem correct to me. The one I'm less certain about is a change around line 216 in `rendering.js` - I'm not sure how `const apps` is used. This might break stuff, or it might not. My testing didn't indicate any issues, but I don't have the whole test harness working - I mostly did it by hand, so, not all code paths for sure. Help & testing would be appreciated!

```js
    const apps = keys(this.store.getters.projectData(projectid).apps).filter(
      app_id => this.store.getters.appData(app_id) !== undefined
    ).map(app_id =>{
      const app = this.store.getters.appData(app_id)

      if (app == undefined) return

      // In the line below - I added the filter
      const models = this.get_models(app_id).filter(model => !model.abstract)
```