### PR TITLE
Use example formatting in placeholders. Labels++

### DIFF
--- a/src/schemas.js
+++ b/src/schemas.js
@@ -55,7 +55,7 @@ const app = () => [
 const model = () => [
   {
     fieldType: "TextInput",
-    placeholder: "ModelNameHere",
+    placeholder: "ModelName",
     label: "Model Name (Used in code + templates; CamelCase recommended)",
     name: "name",
     required: true,
@@ -78,8 +78,8 @@ const model = () => [
 const field = () => [
   {
     fieldType: "TextInput",
-    placeholder: "field_name_here",
-    label: "Name",
+    placeholder: "field_name",
+    label: "Field name (Used in code + templates; snake_case recommended)",
     name: "name",
     required: true,
     nospaces: true

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -44,8 +44,8 @@ const project = () => [
 const app = () => [
   {
     fieldType: "TextInput",
-    placeholder: "This will be the importable python name for your app.",
-    label: "Application Name",
+    placeholder: "app_name",
+    label: "Application Name (This will be the importable python name for your app)",
     name: "name",
     required: true,
     nospaces: true
@@ -55,8 +55,8 @@ const app = () => [
 const model = () => [
   {
     fieldType: "TextInput",
-    placeholder: "amodel",
-    label: "Model Name",
+    placeholder: "ModelNameHere",
+    label: "Model Name (Used in code + templates; CamelCase recommended)",
     name: "name",
     required: true,
     nospaces: true
@@ -78,7 +78,7 @@ const model = () => [
 const field = () => [
   {
     fieldType: "TextInput",
-    placeholder: "afield",
+    placeholder: "field_name_here",
     label: "Name",
     name: "name",
     required: true,


### PR DESCRIPTION
Update labels w/descriptions, instead of placeholder fields. This includes:

## Changes

### CamelCase / CapNames for Models 

e.g. `Person` not `person`, `LibraryBook` not `library_book` or `librarybook`

This is the norm, per: 
- [Django Examples](https://docs.djangoproject.com/en/4.2/topics/db/models/)
- [PEP-8 "Class Names"](https://peps.python.org/pep-0008/#class-names)

### app_name with underscores

This is the norm in general as well, examples provided if needed!

### attribute_names with underscores

e.g. `first_name` not `firstname` etc. - all I did here was make the placeholder a bit more obvious. Examples also provided on request.

## Reasoning

The placeholder text `amodel` led me to create a project with models like `audio_file` and `author` instead of `AudioFile` and `Author`. In theory I should have known better, **but**, I let my GUI-brain treat the hints literally. Whoops! I figured I wouldn't be the only person who ended up having to do a bunch of ultimately unneccesary refactoring and find/replace work, so, here's what should hopefully help!