### PR TITLE
fix(deploy): handle missing target name argument cleanly

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -4,9 +4,9 @@ set -e
 
 NAME=$1
 
-if [ $1 == "" ] ; then
+if [ -z "$NAME" ] ; then
     echo 'Name not given as argument 1'
-    exit 0
+    exit 1
 fi
 
 firebase use ${NAME} || exit 1


### PR DESCRIPTION
## Summary
Running `./script/deploy.sh` with no argument was failing with:

```
./script/deploy.sh: line 7: [: ==: unary operator expected
```

Because `$1` was unquoted in `[ $1 == "" ]`, an empty `$1` left `test` with just `==` and `""` — which `[` interprets as a malformed unary expression.

## Changes
- `script/deploy.sh`: replace `[ $1 == "" ]` with `[ -z "\$NAME" ]` and change `exit 0` to `exit 1` so the missing-arg case is reported as a failure rather than a silent success.

## Test plan
- [x] `bash -n script/deploy.sh` passes (syntax OK).
- [x] `./script/deploy.sh` (no arg) prints `Name not given as argument 1` and exits with status `1`.
- [ ] `./script/deploy.sh somename` still proceeds into the firebase/build path (not run here; requires firebase login).

Made with [Cursor](https://cursor.com)